### PR TITLE
Reset WiFi on AP Connection failure

### DIFF
--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -467,11 +467,16 @@ net_loop()
   // Manage state while connecting
   if(isClientOnly && !WiFi.isConnected())
   {
-    // If we have failed to connect turn on the AP
-    if(client_disconnects > 2) {
-      startAP();
-      client_retry = true;
-      client_retry_time = millis() + WIFI_CLIENT_RETRY_TIMEOUT;
+    // Reset WiFi and try again
+    if (client_disconnects > 2) {
+      WiFi.persistent(false);
+      WiFi.disconnect();
+      WiFi.mode(WIFI_OFF);
+      WiFi.mode(WIFI_STA);
+
+      DEBUG.println("Had 3 disconnects - resetting WiFi");
+      client_disconnects = 0;
+      startClient();
     }
   }
 


### PR DESCRIPTION
#205 Failure to connect to AP when signal is poor.
Replace existing behaviour: reset WiFi and retry connection at third failure instead of invoking AP mode (which may still be achieved through use of button).

NB This succeeds whereas 5 minute AP mode expiring and resetting the ESP32 does not, this results in a continuous loop as the failure to connect persists.
As an alternative (others may judge preferable) AP mode may be invoked for 5 mins as previously - then replace line #487 net_manager.cpp

> ESPAL.reset();

with

>       WiFi.persistent(false);
>       WiFi.disconnect();
>       WiFi.mode(WIFI_OFF);
>       WiFi.mode(WIFI_STA);
> 
>       DEBUG.println("Had 3 disconnects - resetting WiFi");
>       client_disconnects = 0;
>       startClient();
> 

should the temporary AP mode be judged important.