### PR TITLE
Bump to latest MicroTasks

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -39,7 +39,7 @@ lib_deps =
   OpenEVSE@0.0.7
   ESPAL@0.0.1
   StreamSpy@0.0.1
-  MicroTasks@0.0.1
+  MicroTasks@0.0.2
   ESP32 AnalogWrite@0.2
   lorol/LittleFS_esp32@1.0.5
 extra_scripts = scripts/extra_script.py


### PR DESCRIPTION
Prevents lockup should EVSE Monitor be started twice. We possibly should look at why this is happening, but I think it is 'ok' as there are a few paths that could cause the the RAPI to detect the EVSE as booted so fixed MicroTasks to prevent multiple starts.

FIxes #169