### PR TITLE
Only update to the EVSE time if later than the ESP32 time.

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -137,8 +137,11 @@ handleRapiRead()
   {
     if(RAPI_RESPONSE_OK == ret)
     {
-      struct timeval set_time = { evse_time, 0 };
-      settimeofday(&set_time, NULL);
+      time_t local_time = time(NULL);
+      if(evse_time > local_time) {
+        struct timeval set_time = { evse_time, 0 };
+        settimeofday(&set_time, NULL);
+      }
     }
   });
 

--- a/src/time_man.cpp
+++ b/src/time_man.cpp
@@ -60,6 +60,10 @@ unsigned long TimeManager::loop(MicroTasks::WakeReason reason)
          WakeReason_Manual == reason ? "WakeReason_Manual" :
          "UNKNOWN");
 
+  timeval local_time;
+  gettimeofday(&local_time, NULL);
+  DBUGF("Local time: %s", time_format_time(local_time.tv_sec).c_str());
+
   DBUGVAR(_nextCheckTime);
   DBUGVAR(_setTheTime);
 
@@ -155,6 +159,8 @@ void TimeManager::setTime(struct timeval setTime, const char *source)
         _setTheTime = true;
         MicroTask.wakeTask(this);
       }
+    } else {
+      DBUGF("Failed to get the EVSE time: %d", ret);
     }
   });
 


### PR DESCRIPTION
On making a connection to the EVSE we read the time as the EVSE module may have a battery backed RTC or even just it has remained on during reboot.

However it also may not have a useful time set, eg when recovering from a power cut and no battery backed RTC. In ths case there is a race condition between getting the time from NTP and the time from the EVSE. So now we only set to the EVSE time if it is later than the local ESP time.

This fixes NTP not automatically working  #194.