### PR TITLE
Fixed crash when enabling the access point/factory resetting via the button

### DIFF
--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -256,15 +256,17 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
     nextUpdate = nextInfoDelay;
   }
 
+  DBUGVAR(nextUpdate);
   return nextUpdate;
 }
 
 unsigned long LcdTask::displayNextMessage()
 {
-  while(millis() >= _nextMessageTime)
+  while(_head && millis() >= _nextMessageTime)
   {
     // Pop a message from the queue
     Message *msg = _head;
+    DBUGF("msg = %p", msg);
     _head = _head->getNext();
     if(NULL == _head) {
       _tail = NULL;
@@ -282,7 +284,9 @@ unsigned long LcdTask::displayNextMessage()
     _updateInfoLine = true;
   }
 
-  return _nextMessageTime - millis();
+  unsigned long nextUpdate = _nextMessageTime - millis();
+  DBUGVAR(nextUpdate);
+  return nextUpdate;
 }
 
 

--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -408,7 +408,7 @@ net_setup()
   ETH.begin();
 #endif
 
-  if (MDNS.begin(esp_hostname.c_str())) 
+  if (MDNS.begin(esp_hostname.c_str()))
   {
     MDNS.addService("http", "tcp", 80);
     MDNS.addService("openevse", "tcp", 80);
@@ -466,6 +466,8 @@ net_loop()
   }
   else if(false == apMessage && LOW == wifiButtonState && millis() > wifiButtonTimeOut + WIFI_BUTTON_AP_TIMEOUT)
   {
+    DBUGLN("*** Enable Access Point ***");
+
     lcd.display(F("Access Point"), 0, 0, 0, LCD_CLEAR_LINE | LCD_DISPLAY_NOW);
     lcd.display(F(""), 0, 1, 10 * 1000, LCD_CLEAR_LINE | LCD_DISPLAY_NOW);
     apMessage = true;


### PR DESCRIPTION
When there are multiple messages to display immediately the we where missing the null check on the loop.

Fixes #251