### PR TITLE
Corrected the LED setting for NodeMCU boards

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -105,7 +105,7 @@ src_build_flags =
   ${common.version}.dev
   ${common.src_build_flags}
   ${common.debug_flags}
-  -D WIFI_LED=LED_BUILTIN
+  -D WIFI_LED=2
   -D WIFI_LED_ON_STATE=LOW
   -D RAPI_PORT=Serial2
 build_flags =


### PR DESCRIPTION
`LED_BUILTIN` was not set to `0` so was pulling the button low and getting stuck in a reset loop.

Fixes #254