### PR TITLE
Updated to scale the energy values

### DIFF
--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -498,15 +498,16 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
   {
     case LcdInfoLine::EnergySession:
       // Energy 1,018Wh
-      displayNumberValue(1, "Energy", _evse->getSessionEnergy(), 2, "Wh");
+      displayScaledNumberValue(1, "Energy", _evse->getSessionEnergy(), 1, "Wh");
       _updateInfoLine = false;
       break;
 
-    case LcdInfoLine::EnergyTotal:
+    case LcdInfoLine::EnergyTotal: {
       // Lifetime 2313kWh
-      displayNumberValue(1, "Lifetime", _evse->getTotalEnergy(), 0, "kWh");
+      double totalEnergy = _evse->getTotalEnergy() * 1000;
+      displayScaledNumberValue(1, "Lifetime", totalEnergy, 0, "Wh");
       _updateInfoLine = false;
-      break;
+    } break;
 
     case LcdInfoLine::Temperature:
       // EVSE Temp 30.5C
@@ -534,8 +535,8 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
       gettimeofday(&local_time, NULL);
       struct tm timeinfo;
       localtime_r(&local_time.tv_sec, &timeinfo);
-      strftime(temp, sizeof(temp), "Date %d/%m/%Y", &timeinfo);
-      showText(0, 1, temp, true);
+      strftime(temp, sizeof(temp), "%d/%m/%Y", &timeinfo);
+      displayNameValue(1, "Date", temp);
       _updateInfoLine = false;
       } break;
 
@@ -593,7 +594,7 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
         displayStopWatchTime("Left", delay);
         nextUpdate = 1000;
       } else {
-        showText(0, 1, "Left --:--:--", true);
+        displayNameValue(1, "Left", "--:--:--");
         _updateInfoLine = false;
       }
     } break;
@@ -607,11 +608,36 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
   }
 }
 
+void LcdTask::displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit)
+{
+  static const char *mod[] = {
+    "",
+    "k",
+    "m",
+    "g",
+    "t",
+    "p"
+  };
+
+  int index = 0;
+  while (value > 1000 && index < ARRAY_ITEMS(mod))
+  {
+    value /= 1000;
+    index++;
+  }
+
+  char newUnit[20];
+  sprintf(newUnit, "%s%s", mod[index], unit);
+
+  displayNumberValue(line, name, value, precision, newUnit);
+}
+
 void LcdTask::displayNumberValue(int line, const char *name, double value, int precision, const char *unit)
 {
-  char temp[20];
-  sprintf(temp, "%s %.*f%s", name, precision, value, unit);
-  showText(0, line, temp, true);
+  char number[20];
+  snprintf(number, sizeof(number), "%.*f%s", precision, value, unit);
+
+  displayNameValue(line, name, number);
 }
 
 void LcdTask::displayInfoEventTime(const char *name, Scheduler::EventInstance &event)
@@ -632,7 +658,7 @@ void LcdTask::displayInfoEventTime(const char *name, Scheduler::EventInstance &e
   } else {
     sprintf(temp, "%s --:--", name);
   }
-  showText(0, 1, temp, true);
+  displayNameValue(1, name, temp);
 }
 
 void LcdTask::displayStopWatchTime(const char *name, uint32_t time)
@@ -641,8 +667,28 @@ void LcdTask::displayStopWatchTime(const char *name, uint32_t time)
   int hour = time / 3600;
   int min = (time / 60) % 60;
   int sec = time % 60;
-  sprintf(temp, "%s %d:%02d:%02d", name, hour, min, sec);
-  showText(0, 1, temp, true);
+  sprintf(temp, "%d:%02d:%02d", hour, min, sec);
+  displayNameValue(1, name, temp);
+}
+
+void LcdTask::displayNameValue(int line, const char *name, const char *value)
+{
+  int nameLen = strlen(name);
+  int valueLen = strlen(value) + 1;
+  if(nameLen + valueLen > LCD_MAX_LEN) {
+    nameLen = LCD_MAX_LEN - valueLen;
+  } else {
+    valueLen = LCD_MAX_LEN - nameLen;
+  }
+
+  DBUGVAR(nameLen);
+  DBUGVAR(name);
+  DBUGVAR(valueLen);
+  DBUGVAR(value);
+
+  char temp[20];
+  snprintf(temp, sizeof(temp), "%.*s%*s", nameLen, name, valueLen, value);
+  showText(0, line, temp, true);
 }
 
 void LcdTask::showText(int x, int y, const char *msg, bool clear)

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -133,7 +133,9 @@ class LcdTask : public MicroTasks::Task
     void displayStateLine(uint8_t EvseState, unsigned long &nextUpdate);
     void displayInfoLine(LcdInfoLine info, unsigned long &nextUpdate);
     void displayNumberValue(int line, const char *name, double value, int precision, const char *unit);
+    void displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit);
     void displayInfoEventTime(const char *name, Scheduler::EventInstance &event);
+    void displayNameValue(int line, const char *name, const char *value);
     void displayStopWatchTime(const char *name, uint32_t time);
   protected:
     void setup();


### PR DESCRIPTION
The Session and Lifetime values will now automatically scale as the number increases from Wh->kWh->mWh and so on.

Also right justify the the values to look a bit nearer .

Fixes Display session energy as kW with one decimal place #264