### PR TITLE
Fixes for extra chars when displaying the timer start/stop times

### DIFF
--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -665,9 +665,9 @@ void LcdTask::displayInfoEventTime(const char *name, Scheduler::EventInstance &e
       hour = 12;
     }
 
-    sprintf(temp, "%s %d:%02d %s", name, hour, min, pm ? "PM" : "AM");
+    sprintf(temp, "%d:%02d %s", hour, min, pm ? "PM" : "AM");
   } else {
-    sprintf(temp, "%s --:--", name);
+    sprintf(temp, "--:--");
   }
   displayNameValue(1, name, temp);
 }


### PR DESCRIPTION
When displaying the timer start/stop times the Start/Stop was being included in the `value` parameter of `displayNameValue` so it was getting repeated. This change removes that duplication, fixes #305