### PR TITLE
LCD info display corrections and date format tweak

### DIFF
--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -546,7 +546,7 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
       gettimeofday(&local_time, NULL);
       struct tm timeinfo;
       localtime_r(&local_time.tv_sec, &timeinfo);
-      strftime(temp, sizeof(temp), "%d/%m/%Y", &timeinfo);
+      strftime(temp, sizeof(temp), "%Y-%m-%d", &timeinfo);
       displayNameValue(1, "Date", temp);
       _updateInfoLine = false;
       } break;

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -624,10 +624,10 @@ void LcdTask::displayScaledNumberValue(int line, const char *name, double value,
   static const char *mod[] = {
     "",
     "k",
-    "m",
-    "g",
-    "t",
-    "p"
+    "M",
+    "G",
+    "T",
+    "P"
   };
 
   int index = 0;


### PR DESCRIPTION
The metric units fix here should be uncontroversial- we need to be using `MWh`, not `mWh`, to be megawatt-hours, not milliwatt-hours. https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes

The date one might be a bit less desired, but I'd advocate for making the change. The OpenEVSE web UI has the advantage of being able to use the browser/OS date format, but the LCD display format is hardcoded. By using the ISO date format, there should be no confusion with a date such as "04/07/2022" - is this April 7th (as a US resident would likely interpret it), or July 4th (as most of the rest of the world would use)? By displaying "2022-07-04", it is much less ambiguous.