### PR TITLE
Extend MQTT to set state / max_current / charge_current

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ lib/MicroTasks
 
 *.bin
 
+/%SystemDrive%

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -1,0 +1,44 @@
+### MQTT
+
+MQTT and MQTTS (secure) connections are supported for status and control.
+
+At startup the following message is published with a retain flag to `openevse/announce/xxxx` where `xxxx` is the last 4 characters of the device ID. This message is useful for device discovery and contans the device hostname and IP address.
+
+```json
+{
+  "state":"connected",
+  "id":"c44f330dxxad",
+  "name":"openevse-55ad",
+  "mqtt":"emon/openevse-55ad",
+  "http":"http://192.168.1.43/"
+}
+```
+
+For device discovery you should subscribe with a wild card to `openevse/announce/#`
+
+When the device disconnects from MQTT the same message is posted with `state":"disconnected"` (Last Will and Testament).
+
+All subsequent MQTT status updates will by default be be posted to `openevse-xxxx` where `xxxx` is the last 4 characters of the device ID. This base-topic can be changed via the MQTT service page.
+
+#### OpenEVSE Status via MQTT
+
+OpenEVSE can post its status values (e.g. amp, wh, temp1, temp2, temp3, pilot, status) to an MQTT server. Data will be published as a sub-topic of base topic, e.g `<base-topic>/amp`. Data is published to MQTT every 30s.
+
+**The default `<base-topic>` is `openevse-xxxx` where `xxxx` is the last 4 characters of the device ID**
+
+Controls:
+
+`<base-topic>/divertmode/set`      : [1 (disable) | 2 (enable)] divert mode
+`<base-topic>/max_current/set`     : [int in A] set max software current value
+`<base-topic>/pilot/set`           : [in in A] override charge current/pilot. Use `<base-topic>/manual_override/set delete` to remove overrides.
+`<base-topic>/manual_override/set` : [start / stop / delete] Manually enable / disable charge. Using delete remove the override.
+
+
+MQTT setup is pre-populated with OpenEnergyMonitor [emonPi default MQTT server credentials](https://guide.openenergymonitor.org/technical/credentials/#mqtt).
+
+* Enter MQTT server host and base-topic
+* (Optional) Enter server authentication details if required
+* Click connect
+* After a few seconds `Connected: No` should change to `Connected: Yes` if connection is successful. Re-connection will be attempted every 10s. A refresh of the page may be needed.
+
+*Note: `emon/xxxx` should be used as the base-topic if posting to emonPi MQTT server if you want the data to appear in emonPi Emoncms. See [emonPi MQTT docs](https://guide.openenergymonitor.org/technical/mqtt/).*

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -136,6 +136,8 @@ Data can be posted using HTTP or HTTPS.
 
 ### MQTT
 
+Refer to MQTT.md documentation
+
 MQTT and MQTTS (secure) connections are supported for status and control.
 
 At startup the following message is published with a retain flag to `openevse/announce/xxxx` where `xxxx` is the last 4 characters of the device ID. This message is useful for device discovery and contans the device hostname and IP address.
@@ -164,9 +166,9 @@ OpenEVSE can post its status values (e.g. amp, wh, temp1, temp2, temp3, pilot, s
 
 Controls:
 
- `<base-topic>/divertmode/set`     : [1 (disable) | 2 (enable)] divert mode
+`<base-topic>/divertmode/set`      : [1 (disable) | 2 (enable)] divert mode
 `<base-topic>/max_current/set`     : [int in A] set max software current value
-`<base-topic>/pilot/set`           : [in in A] override charge current/pilot. Use `<base-topic>/manual_override/set delete` to remove claims.
+`<base-topic>/pilot/set`           : [in in A] override charge current/pilot. Use `<base-topic>/manual_override/set delete` to remove overrides.
 `<base-topic>/manual_override/set` : [start / stop / delete] Manually enable / disable charge. Using delete remove the override.
 
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -162,6 +162,14 @@ OpenEVSE can post its status values (e.g. amp, wh, temp1, temp2, temp3, pilot, s
 
 **The default `<base-topic>` is `openevse-xxxx` where `xxxx` is the last 4 characters of the device ID**
 
+Controls:
+
+ `<base-topic>/divertmode/set`     : [1 (disable) | 2 (enable)] divert mode
+`<base-topic>/max_current/set`     : [int in A] set max software current value
+`<base-topic>/charge_current/set`  : [in in A] override charge current. Use `<base-topic>/manual_override/set delete` to remove claims.
+`<base-topic>/manual_override/set` : [start / stop / delete] Manually enable / disable charge. Using delete remove the override.
+
+
 MQTT setup is pre-populated with OpenEnergyMonitor [emonPi default MQTT server credentials](https://guide.openenergymonitor.org/technical/credentials/#mqtt).
 
 * Enter MQTT server host and base-topic

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -166,7 +166,7 @@ Controls:
 
  `<base-topic>/divertmode/set`     : [1 (disable) | 2 (enable)] divert mode
 `<base-topic>/max_current/set`     : [int in A] set max software current value
-`<base-topic>/charge_current/set`  : [in in A] override charge current. Use `<base-topic>/manual_override/set delete` to remove claims.
+`<base-topic>/pilot/set`           : [in in A] override charge current/pilot. Use `<base-topic>/manual_override/set delete` to remove claims.
 `<base-topic>/manual_override/set` : [start / stop / delete] Manually enable / disable charge. Using delete remove the override.
 
 

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -33,6 +33,7 @@ typedef uint32_t EvseClient;
 #define EvseClient_OpenEVSE_Ohm               EVC(EvseClient_Vendor_OpenEVSE, 0x0008)
 #define EvseClient_OpenEVSE_Ocpp              EVC(EvseClient_Vendor_OpenEVSE, 0x0009)
 #define EvseClient_OpenEVSE_RFID              EVC(EvseClient_Vendor_OpenEVSE, 0x000A)
+#define EvseClient_OpenEVSE_MQTT              EVC(EvseClient_Vendor_OpenEVSE, 0x000B)
 
 #define EvseClient_OpenEnergyMonitor_DemandShaper EVC(EvseClient_Vendor_OpenEnergyMonitor, 0x0001)
 
@@ -43,6 +44,7 @@ typedef uint32_t EvseClient;
 #define EvseManager_Priority_Timer     100
 #define EvseManager_Priority_Boost     200
 #define EvseManager_Priority_API       500
+#define EvseManager_Priority_MQTT      500
 #define EvseManager_Priority_Ohm       500
 #define EvseManager_Priority_Manual   1000
 #define EvseManager_Priority_RFID     1030

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -91,6 +91,7 @@ void create_rapi_json(JsonDocument &doc)
   doc["amp"] = evse.getAmps() * AMPS_SCALE_FACTOR;
   doc["voltage"] = evse.getVoltage() * VOLTS_SCALE_FACTOR;
   doc["pilot"] = evse.getChargeCurrent();
+  doc["max_current"] = evse.getMaxCurrent();
   doc["wh"] = evse.getTotalEnergy() * TOTAL_ENERGY_SCALE_FACTOR;
   doc["session_energy"] = evse.getSessionEnergy();
   doc["total_energy"] = evse.getTotalEnergy();

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -129,13 +129,13 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
   {
       DBUGF("Set evse state: %d", newmode);     
       if (payload_str.equals("stop")) {
-        // stop/pause using override like web interface 
+        // stop/pause using override
         EvseProperties props;
         props.setState(EvseState::Disabled);
         evse.claim(EvseClient_OpenEVSE_Manual, EvseManager_Priority_Manual, props);
       }     
       else if (payload_str.equals("start")) {
-        // start/unpause using override like web interface 
+        // start/unpause using override
         EvseProperties props;
         props.setState(EvseState::Active);
         evse.claim(EvseClient_OpenEVSE_Manual, EvseManager_Priority_Manual, props);

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -116,7 +116,7 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
     //We have a confusion in web interface to solve as details of the override are not displayed
     EvseProperties props(EvseState::Active);
     props.setChargeCurrent(newchargecurrent);
-    evse.claim(EvseClient_OpenEVSE_Manual, EvseManager_Priority_Manual, props);
+    evse.claim(EvseClient_OpenEVSE_MQTT, EvseManager_Priority_MQTT, props);
   }
   else if (topic_string == mqtt_topic + "/max_current/set")
   {
@@ -132,17 +132,17 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
         // stop/pause using override
         EvseProperties props;
         props.setState(EvseState::Disabled);
-        evse.claim(EvseClient_OpenEVSE_Manual, EvseManager_Priority_Manual, props);
+        evse.claim(EvseClient_OpenEVSE_MQTT, EvseManager_Priority_MQTT, props);
       }     
       else if (payload_str.equals("start")) {
         // start/unpause using override
         EvseProperties props;
         props.setState(EvseState::Active);
-        evse.claim(EvseClient_OpenEVSE_Manual, EvseManager_Priority_Manual, props);
+        evse.claim(EvseClient_OpenEVSE_MQTT, EvseManager_Priority_MQTT, props);
       }
       else if (payload_str.equals("delete")) {
         // remove override
-        evse.release(EvseClient_OpenEVSE_Manual);
+        evse.release(EvseClient_OpenEVSE_MQTT);
       }      
   }
   else

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -108,7 +108,7 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
       divertmode_update(newdivert);
     }
   }
-  else if (topic_string == mqtt_topic + "/charge_current/set")
+  else if (topic_string == mqtt_topic + "/pilot/set")
   {
     int newchargecurrent = payload_str.toInt();
     DBUGF("Set charge_current: %d", newmode);


### PR DESCRIPTION
Fixes #358

mqtt: set override ( start/stop/delete)
mqtt: publish max_current
mqtt  set charge_current + max_current

 Not sure of my choices, let me know if some approach are bad.

perhaps should I rename /charge_current/set as /pilot/set to stay coherent ?