### PR TITLE
Issue #187 - Feed watchdog in http_update_write()

### DIFF
--- a/src/http_update.cpp
+++ b/src/http_update.cpp
@@ -88,6 +88,11 @@ bool http_update_start(String source, size_t total)
 
 bool http_update_write(uint8_t *data, size_t len)
 {
+  // Issue #187 "HTTP update fails on ESP32 ethernet gateway" was caused by the
+  // loop watchdog timing out, presumably because updating wasn't bottlenecked
+  // by network and execution stayed in the Mongoose poll() method.
+  feedLoopWDT();
+
   DBUGF("Update Writing %u, %u", update_position, len);
   size_t written = Update.write(data, len);
   DBUGVAR(written);


### PR DESCRIPTION
I've only spent a couple minutes testing this on an ESP32-PoE-ISO board, but it seems to work, and it compiles OK for the targets on the releases page.

Fixes #187