### PR TITLE
Added the ability to set some write once 'factory' settings

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,7 @@ lib_deps =
   bblanchon/ArduinoJson@6.19.1
   jeremypoulter/ArduinoMongoose@0.0.18
   jeremypoulter/Micro Debug@0.0.5
-  jeremypoulter/ConfigJson@0.0.4
+  jeremypoulter/ConfigJson@0.0.5
   jeremypoulter/OpenEVSE@0.0.11
   jeremypoulter/ESPAL@0.0.3
   jeremypoulter/StreamSpy@0.0.1
@@ -68,6 +68,7 @@ build_flags =
   -D CS_PLATFORM=CS_P_ESP32
   -D MG_ENABLE_SSL=1
   -D MG_ENABLE_HTTP_STREAMING_MULTIPART=1
+  -D MG_ENABLE_EXTRA_ERRORS_DESC=1
   -D MG_SSL_MBED_DUMMY_RANDOM=1
   -D MG_SSL_IF=MG_SSL_IF_MBEDTLS
   -D MG_SSL_IF_MBEDTLS_FREE_CERTS=1

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -16,9 +16,15 @@
 #include <Arduino.h>
 #include <EEPROM.h>             // Save config settings
 #include <ConfigJson.h>
+#include <LITTLEFS.h>
 
-#define EEPROM_SIZE     4096
-#define CHECKSUM_SEED    128
+#define EEPROM_SIZE       4096
+
+#define CONFIG_OFFSET     0
+#define CONFIG_SIZE       3072
+
+#define FACTORY_OFFSET    CONFIG_SIZE
+#define FACTORY_SIZE      1024
 
 // Wifi Network Strings
 String esid;
@@ -115,7 +121,7 @@ ConfigOpt *opts[] =
 
 // Language String
   new ConfigOptDefenition<String>(lang, "", "lang", "lan"),
-  
+
 // Web server authentication (leave blank for none)
   new ConfigOptDefenition<String>(www_username, "", "www_username", "au"),
   new ConfigOptSecret(www_password, "", "www_password", "ap"),
@@ -203,11 +209,13 @@ ConfigOpt *opts[] =
   new ConfigOptVirtualBool(flagsOpt, CONFIG_OCPP_ACCESS_SUSPEND, CONFIG_OCPP_ACCESS_SUSPEND, "ocpp_suspend_evse", "ops"),
   new ConfigOptVirtualBool(flagsOpt, CONFIG_OCPP_ACCESS_ENERGIZE, CONFIG_OCPP_ACCESS_ENERGIZE, "ocpp_energize_plug", "opn"),
   new ConfigOptVirtualBool(flagsOpt, CONFIG_RFID, CONFIG_RFID, "rfid_enabled", "rf"),
+  new ConfigOptVirtualBool(flagsOpt, CONFIG_FACTORY_WRITE_LOCK, CONFIG_FACTORY_WRITE_LOCK, "factory_write_lock", "fwl"),
   new ConfigOptVirtualMqttProtocol(flagsOpt, "mqtt_protocol", "mprt"),
   new ConfigOptVirtualChargeMode(flagsOpt, "charge_mode", "chmd")
 };
 
-ConfigJson config(opts, sizeof(opts) / sizeof(opts[0]), EEPROM_SIZE);
+ConfigJson user_config(opts, sizeof(opts) / sizeof(opts[0]), EEPROM_SIZE, CONFIG_OFFSET);
+ConfigJson factory_config(opts, sizeof(opts) / sizeof(opts[0]), EEPROM_SIZE, FACTORY_OFFSET);
 
 // -------------------------------------------------------------------
 // Reset EEPROM, wipes all settings
@@ -217,7 +225,7 @@ ResetEEPROM() {
   EEPROM.begin(EEPROM_SIZE);
 
   //DEBUG.println("Erasing EEPROM");
-  for (int i = 0; i < EEPROM_SIZE; ++i) {
+  for (int i = CONFIG_OFFSET; i < (CONFIG_OFFSET + CONFIG_SIZE); ++i) {
     EEPROM.write(i, 0xff);
     //DEBUG.print("#");
   }
@@ -230,9 +238,10 @@ ResetEEPROM() {
 void
 config_load_settings()
 {
-  config.onChanged(config_changed);
+  user_config.onChanged(config_changed);
 
-  if(!config.load()) {
+  factory_config.load(false);
+  if(!user_config.load(true)) {
     DBUGF("No JSON config found, trying v1 settings");
     config_load_v1_settings();
   }
@@ -279,46 +288,48 @@ void config_changed(String name)
   }
 }
 
-void config_commit()
+void config_commit(bool factory)
 {
+  ConfigJson &config = factory ? factory_config : user_config;
+  config.set("factory_write_lock", true);
   config.commit();
 }
 
 bool config_deserialize(String& json) {
-  return config.deserialize(json.c_str());
+  return user_config.deserialize(json.c_str());
 }
 
 bool config_deserialize(const char *json)
 {
-  return config.deserialize(json);
+  return user_config.deserialize(json);
 }
 
 bool config_deserialize(DynamicJsonDocument &doc)
 {
-  return config.deserialize(doc);
+  return user_config.deserialize(doc);
 }
 
 bool config_serialize(String& json, bool longNames, bool compactOutput, bool hideSecrets)
 {
-  return config.serialize(json, longNames, compactOutput, hideSecrets);
+  return user_config.serialize(json, longNames, compactOutput, hideSecrets);
 }
 
 bool config_serialize(DynamicJsonDocument &doc, bool longNames, bool compactOutput, bool hideSecrets)
 {
-  return config.serialize(doc, longNames, compactOutput, hideSecrets);
+  return user_config.serialize(doc, longNames, compactOutput, hideSecrets);
 }
 
 void config_set(const char *name, uint32_t val) {
-  config.set(name, val);
+  user_config.set(name, val);
 }
 void config_set(const char *name, String val) {
-  config.set(name, val);
+  user_config.set(name, val);
 }
 void config_set(const char *name, bool val) {
-  config.set(name, val);
+  user_config.set(name, val);
 }
 void config_set(const char *name, double val) {
-  config.set(name, val);
+  user_config.set(name, val);
 }
 
 void config_save_emoncms(bool enable, String server, String node, String apikey,
@@ -329,12 +340,12 @@ void config_save_emoncms(bool enable, String server, String node, String apikey,
     newflags |= CONFIG_SERVICE_EMONCMS;
   }
 
-  config.set("emoncms_server", server);
-  config.set("emoncms_node", node);
-  config.set("emoncms_apikey", apikey);
-  config.set("emoncms_fingerprint", fingerprint);
-  config.set("flags", newflags);
-  config.commit();
+  user_config.set("emoncms_server", server);
+  user_config.set("emoncms_node", node);
+  user_config.set("emoncms_apikey", apikey);
+  user_config.set("emoncms_fingerprint", fingerprint);
+  user_config.set("flags", newflags);
+  user_config.commit();
 }
 
 void
@@ -352,23 +363,23 @@ config_save_mqtt(bool enable, int protocol, String server, uint16_t port, String
   }
   newflags |= protocol << 4;
 
-  config.set("mqtt_server", server);
-  config.set("mqtt_port", port);
-  config.set("mqtt_topic", topic);
-  config.set("mqtt_user", user);
-  config.set("mqtt_pass", pass);
-  config.set("mqtt_solar", solar);
-  config.set("mqtt_grid_ie", grid_ie);
-  config.set("mqtt_live_pwr", live_pwr);
-  config.set("flags", newflags);
-  config.commit();
+  user_config.set("mqtt_server", server);
+  user_config.set("mqtt_port", port);
+  user_config.set("mqtt_topic", topic);
+  user_config.set("mqtt_user", user);
+  user_config.set("mqtt_pass", pass);
+  user_config.set("mqtt_solar", solar);
+  user_config.set("mqtt_grid_ie", grid_ie);
+  user_config.set("mqtt_live_pwr", live_pwr);
+  user_config.set("flags", newflags);
+  user_config.commit();
 }
 
 void
 config_save_admin(String user, String pass) {
-  config.set("www_username", user);
-  config.set("www_password", pass);
-  config.commit();
+  user_config.set("www_username", user);
+  user_config.set("www_password", pass);
+  user_config.commit();
 }
 
 void
@@ -379,9 +390,9 @@ config_save_sntp(bool sntp_enable, String tz)
     newflags |= CONFIG_SERVICE_SNTP;
   }
 
-  config.set("time_zone", tz);
-  config.set("flags", newflags);
-  config.commit();
+  user_config.set("time_zone", tz);
+  user_config.set("flags", newflags);
+  user_config.commit();
 
   config_set_timezone(tz);
 }
@@ -400,17 +411,17 @@ void config_set_timezone(String tz)
 
 void
 config_save_advanced(String hostname, String sntp_host) {
-  config.set("hostname", hostname);
-  config.set("sntp_hostname", sntp_host);
-  config.commit();
+  user_config.set("hostname", hostname);
+  user_config.set("sntp_hostname", sntp_host);
+  user_config.commit();
 }
 
 void
 config_save_wifi(String qsid, String qpass)
 {
-  config.set("ssid", qsid);
-  config.set("pass", qpass);
-  config.commit();
+  user_config.set("ssid", qsid);
+  user_config.set("pass", qpass);
+  user_config.commit();
 }
 
 void
@@ -421,9 +432,9 @@ config_save_ohm(bool enable, String qohm)
     newflags |= CONFIG_SERVICE_OHM;
   }
 
-  config.set("ohm", qohm);
-  config.set("flags", newflags);
-  config.commit();
+  user_config.set("ohm", qohm);
+  user_config.set("flags", newflags);
+  user_config.commit();
 }
 
 void
@@ -432,19 +443,20 @@ config_save_rfid(bool enable, String storage){
   if(enable) {
     newflags |= CONFIG_RFID;
   }
-  config.set("flags", newflags);
-  config.set("rfid_storage", rfid_storage);
-  config.commit();
+  user_config.set("flags", newflags);
+  user_config.set("rfid_storage", rfid_storage);
+  user_config.commit();
 }
 
 void
 config_save_flags(uint32_t newFlags) {
-  config.set("flags", newFlags);
-  config.commit();
+  user_config.set("flags", newFlags);
+  user_config.commit();
 }
 
 void
 config_reset() {
   ResetEEPROM();
-  config.reset();
+  LittleFS.format();
+  config_load_settings();
 }

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -16,7 +16,7 @@
 extern String esid;
 extern String epass;
 
-// Language 
+// Language
 extern String lang;
 
 // Web server authentication (leave blank for none)
@@ -93,7 +93,7 @@ extern uint32_t flags;
 #define CONFIG_RFID                 (1 << 18)
 #define CONFIG_SERVICE_CUR_SHAPER   (1 << 19)
 #define CONFIG_MQTT_RETAINED        (1 << 20)
-
+#define CONFIG_FACTORY_WRITE_LOCK   (1 << 21)
 
 inline bool config_emoncms_enabled() {
   return CONFIG_SERVICE_EMONCMS == (flags & CONFIG_SERVICE_EMONCMS);
@@ -161,6 +161,10 @@ inline bool config_vehicle_range_miles() {
 
 inline bool config_rfid_enabled() {
   return CONFIG_RFID == (flags & CONFIG_RFID);
+}
+
+inline bool config_factory_write_lock() {
+  return CONFIG_FACTORY_WRITE_LOCK == (flags & CONFIG_FACTORY_WRITE_LOCK);
 }
 
 // Ohm Connect Settings
@@ -233,7 +237,7 @@ void config_set(const char *name, double val);
 bool config_deserialize(String& json);
 bool config_deserialize(const char *json);
 bool config_deserialize(DynamicJsonDocument &doc);
-void config_commit();
+void config_commit(bool factory = false);
 
 // Write config settings to JSON object
 bool config_serialize(String& json, bool longNames = true, bool compactOutput = false, bool hideSecrets = false);

--- a/src/app_config_v1.cpp
+++ b/src/app_config_v1.cpp
@@ -25,7 +25,7 @@
 #define EEPROM_MQTT_PORT_SIZE         4
 #define EEPROM_SNTP_HOST_SIZE         45
 #define EEPROM_TIME_ZONE_SIZE         80
-#define EEPROM_SIZE                   1024
+#define EEPROM_SIZE                   4096
 
 #define EEPROM_ESID_START             0
 #define EEPROM_ESID_END               (EEPROM_ESID_START + EEPROM_ESID_SIZE)

--- a/test/config.http
+++ b/test/config.http
@@ -252,3 +252,17 @@ Content-Type: application/json
   "pass": "{{pass}}"
 }
 
+###
+
+# Set a factory username/password
+
+POST {{baseUrl}}/config?factory=true HTTP/1.1
+Content-Type: application/json
+Authorization: Basic admin:admin
+X-Storage: factory
+
+{
+  "www_username": "admin",
+  "www_password": "admin"
+}
+


### PR DESCRIPTION
By adding the header `X-Storage: factory` to the HTTP on the first call the settings will be saved to a different area of flash. This allows for unique IDs and passwords to be set at the factory that will be preserved after a factory reset.