### PR TITLE
fix  #446 remove force auto_release = true for override

### DIFF
--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -70,7 +70,7 @@ class EvseProperties : virtual public JsonSerialize<512>
     uint32_t _max_current;
     uint32_t _energy_limit;
     uint32_t _time_limit;
-    bool _auto_release;
+    bool _auto_release = true;
   public:
     EvseProperties();
     EvseProperties(EvseState state);

--- a/src/manual.cpp
+++ b/src/manual.cpp
@@ -17,7 +17,6 @@ bool ManualOverride::claim()
 
 bool ManualOverride::claim(EvseProperties &props)
 {
-  props.setAutoRelease(true);
   return _evse->claim(EvseClient_OpenEVSE_Manual, EvseManager_Priority_Manual, props);
 }
 


### PR DESCRIPTION
remove force auto_release = true for override.
add default auto_release to true for EvsProperties

fix https://github.com/OpenEVSE/ESP32_WiFi_V4.x/issues/446