### PR TITLE
Set the charge rate on the schedule

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -222,9 +222,13 @@ unsigned long Scheduler::loop(MicroTasks::WakeReason reason)
       DBUGF("Starting %s claim",
         currentEvent.getState().toString());
       EvseProperties properties(currentEvent.getState());
-      _evse->claim(EvseClient_OpenEVSE_Schedule,
-        EvseState::Active == currentEvent.getState() ? EvseManager_Priority_Timer : EvseManager_Priority_Default,
-        properties);
+      int priority = EvseManager_Priority_Default;
+      if(EvseState::Active == currentEvent.getState())
+      {
+        priority = EvseManager_Priority_Timer;
+        properties.setChargeCurrent(_evse->getMaxHardwareCurrent());
+      }
+      _evse->claim(EvseClient_OpenEVSE_Schedule, priority, properties);
     } else {
       // No scheduled events, release any claims
       DBUGLN("releasing claims");


### PR DESCRIPTION
This is to ensure that the eco mode does not conflict ad the timer will operate as a boost if used at the same as echo mode.

Fixes #459