### PR TITLE
add auto_release to /override

### DIFF
--- a/src/current_shaper.h
+++ b/src/current_shaper.h
@@ -17,6 +17,7 @@
 #include "http_update.h"
 #include "input.h"
 #include "event.h"
+#include "divert.h"
 
 class CurrentShaperTask: public MicroTasks::Task
 {

--- a/src/evse_man.cpp
+++ b/src/evse_man.cpp
@@ -221,8 +221,9 @@ bool EvseManager::evaluateClaims(EvseProperties &properties)
       DBUGVAR(claim.getEnergyLimit());
       DBUGVAR(claim.getTimeLimit());
 
-      if(claim.getPriority() > statePriority &&
-         claim.getState() != EvseState::None)
+      //if(claim.getPriority() > statePriority &&
+        // claim.getState() != EvseState::None)
+      if(claim.getPriority() > statePriority)
       {
         properties.setState(claim.getState());
         statePriority = claim.getPriority();
@@ -269,13 +270,13 @@ bool EvseManager::evaluateClaims(EvseProperties &properties)
         event_send(event);
         // update /override topic to mqtt
         event.clear();
-        EvseState state = properties.getState();
-        if(state != EvseState::None) {
+        //EvseState state = properties.getState();
+        // if(state != EvseState::None) {
           properties.serialize(event);         
-        }
-        else {
-          event["state"] = "null";
-        }
+        //}
+        // else {
+        //   event["state"] = "null";
+        // }
         mqtt_publish_json(event, "/override");
       }
     }

--- a/src/evse_man.cpp
+++ b/src/evse_man.cpp
@@ -79,6 +79,7 @@ bool EvseProperties::deserialize(JsonObject &obj)
 
   if(obj.containsKey("auto_release")) {
     _auto_release = obj["auto_release"];
+    _has_auto_release = true;
   }
 
   return true;

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -71,6 +71,7 @@ class EvseProperties : virtual public JsonSerialize<512>
     uint32_t _energy_limit;
     uint32_t _time_limit;
     bool _auto_release;
+    bool _has_auto_release = false;
   public:
     EvseProperties();
     EvseProperties(EvseState state);
@@ -125,8 +126,14 @@ class EvseProperties : virtual public JsonSerialize<512>
     bool isAutoRelease() {
       return _auto_release;
     }
+
+    bool hasAutoRelease() {
+      return _has_auto_release;
+    }
+
     void setAutoRelease(bool auto_release) {
       _auto_release = auto_release;
+      _has_auto_release = true;
     }
 
     EvseProperties & operator = (EvseProperties &rhs);
@@ -223,6 +230,10 @@ class EvseManager : public MicroTasks::Task
 
         bool isAutoRelease() {
           return _properties.isAutoRelease();
+        }
+
+        bool hasAutoRelease() {
+          return _properties.hasAutoRelease();
         }
 
         EvseProperties &getProperties() {

--- a/src/manual.cpp
+++ b/src/manual.cpp
@@ -17,7 +17,7 @@ bool ManualOverride::claim()
 
 bool ManualOverride::claim(EvseProperties &props)
 {
-  props.setAutoRelease(true);
+  if (!props.hasAutoRelease()) props.setAutoRelease(true);
   return _evse->claim(EvseClient_OpenEVSE_Manual, EvseManager_Priority_Manual, props);
 }
 


### PR DESCRIPTION
After many considerations, 'auto_release' missing from /override will be needed for the uses cases we have talked about.
I've tryied to trick by using /claim with manual_override client ID, but priority is then HTTP Api one ( 500 ) .

Should be done the proper way, default to true if there's no auto_release property in the override claim