### PR TITLE
prevent shaper to control charge_current if divert mode is active

### DIFF
--- a/src/current_shaper.cpp
+++ b/src/current_shaper.cpp
@@ -18,7 +18,7 @@ void CurrentShaperTask::setup() {
 }
 
 unsigned long CurrentShaperTask::loop(MicroTasks::WakeReason reason) {
-	if (_enabled) {
+	if (_enabled && !_evse->clientHasClaim(EvseClient_OpenEVSE_Divert)) {
 			EvseProperties props;
 			if (_changed) {
 				props.setChargeCurrent(_chg_cur);
@@ -104,11 +104,8 @@ void CurrentShaperTask::setState(bool state) {
 }
 
 void CurrentShaperTask::shapeCurrent() {
-	// only use Shaper if there's no Divert claim active ( means divert is active)
-	if (!_evse->clientHasClaim(EvseClient_OpenEVSE_Divert)) {
 	_chg_cur = round(((_max_pwr - _live_pwr) / evse.getVoltage()) + (evse.getAmps()));
 	_changed = true; 
-	}
 }
 
 int CurrentShaperTask::getMaxPwr() {

--- a/src/current_shaper.cpp
+++ b/src/current_shaper.cpp
@@ -97,7 +97,6 @@ void CurrentShaperTask::setState(bool state) {
 	if (!_enabled) {
 		//remove claim
 		evse.release(EvseClient_OpenEVSE_Shaper);
-
 	}
 	StaticJsonDocument<128> event;
 	event["shaper"]  = state?1:0;
@@ -105,8 +104,11 @@ void CurrentShaperTask::setState(bool state) {
 }
 
 void CurrentShaperTask::shapeCurrent() {
+	// only use Shaper if there's no Divert claim active ( means divert is active)
+	if (!_evse->clientHasClaim(EvseClient_OpenEVSE_Divert)) {
 	_chg_cur = round(((_max_pwr - _live_pwr) / evse.getVoltage()) + (evse.getAmps()));
-	_changed = true; // update claim in the loop
+	_changed = true; 
+	}
 }
 
 int CurrentShaperTask::getMaxPwr() {

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -241,7 +241,7 @@ void buildStatus(DynamicJsonDocument &doc) {
   doc["divert_update"] = (millis() - divert.getLastUpdate()) / 1000;
   doc["divert_active"] = divert.isActive();
 
-  doc["shaper"] = shaper.isActive()?1:0;
+  doc["shaper"] = shaper.getState()?1:0;
   doc["shaper_live_pwr"] = shaper.getLivePwr();
   doc["shaper_chg_cur"] = shaper.getChgCur();
 


### PR DESCRIPTION
This should fix some priority issues I'had been reported.
There's no need of shaper doing it's job when divert is active in eco mode