### PR TITLE
Current Shaper now use "max_current" instead of "charge_current".

### DIFF
--- a/src/current_shaper.cpp
+++ b/src/current_shaper.cpp
@@ -21,8 +21,8 @@ unsigned long CurrentShaperTask::loop(MicroTasks::WakeReason reason) {
 	if (_enabled && !_evse->clientHasClaim(EvseClient_OpenEVSE_Divert)) {
 			EvseProperties props;
 			if (_changed) {
-				props.setChargeCurrent(_chg_cur);
-				if (_chg_cur < evse.getMinCurrent() ) {
+				props.setMaxCurrent(_max_cur);
+				if (_max_cur < evse.getMinCurrent() ) {
 					// pause temporary, not enough amps available
 					props.setState(EvseState::Disabled);
 				}
@@ -36,7 +36,8 @@ unsigned long CurrentShaperTask::loop(MicroTasks::WakeReason reason) {
 				event["shaper"]  = 1;
 				event["shaper_live_pwr"] = _live_pwr;
 				event["shaper_max_pwr"] = _max_pwr;
-				event["shaper_cur"]	     = _chg_cur;
+				event["shaper_cur"]	     = _max_cur;
+				event["shaper_updated"] = true;
 				event_send(event);
 			}
 			if (millis() - _timer > EVSE_SHAPER_FAILSAFE_TIME) {
@@ -48,7 +49,8 @@ unsigned long CurrentShaperTask::loop(MicroTasks::WakeReason reason) {
 				event["shaper"]  = 1;
 				event["shaper_live_pwr"] = _live_pwr;
 				event["shaper_max_pwr"] = _max_pwr;
-				event["shaper_cur"]	     = _chg_cur;
+				event["shaper_cur"]	     = _max_cur;
+				event["shaper_updated"] = false;
 				event_send(event);
 			}
 	}
@@ -69,7 +71,7 @@ void CurrentShaperTask::begin(EvseManager &evse) {
 	this -> _evse    = &evse;
 	this -> _max_pwr = current_shaper_max_pwr; 
 	this -> _live_pwr = 0;
-	this -> _chg_cur = 0; 
+	this -> _max_cur = 0; 
 	MicroTask.startTask(this);
 	StaticJsonDocument<128> event;
 	event["shaper"]  = 1;
@@ -110,7 +112,7 @@ void CurrentShaperTask::setState(bool state) {
 }
 
 void CurrentShaperTask::shapeCurrent() {
-	_chg_cur = round(((_max_pwr - _live_pwr) / evse.getVoltage()) + (evse.getAmps()));
+	_max_cur = round(((_max_pwr - _live_pwr) / evse.getVoltage()) + (evse.getAmps()));
 	_changed = true; 
 }
 
@@ -120,8 +122,9 @@ int CurrentShaperTask::getMaxPwr() {
 int CurrentShaperTask::getLivePwr() {
 	return _live_pwr;
 }
-uint8_t CurrentShaperTask::getChgCur() {
-	return _chg_cur;
+
+uint8_t CurrentShaperTask::getMaxCur() {
+	return _max_cur;
 }
 bool CurrentShaperTask::getState() {
 	return _enabled;

--- a/src/current_shaper.h
+++ b/src/current_shaper.h
@@ -25,8 +25,9 @@ class CurrentShaperTask: public MicroTasks::Task
     bool         _enabled;
     bool         _changed;
     int          _max_pwr;   // total current available from the grid
-    int          _live_pwr;   // current available to EVSE
+    int          _live_pwr;  // current available to EVSE
     uint8_t      _chg_cur;   // calculated charge current to claim
+    uint8_t      _max_cur;   // shaper calculated max current
     uint32_t     _timer;
   
   protected:
@@ -46,7 +47,7 @@ class CurrentShaperTask: public MicroTasks::Task
     bool getState();
     int getMaxPwr();
     int getLivePwr();
-    uint8_t getChgCur();
+    uint8_t getMaxCur();
     bool isActive();
 
     void notifyConfigChanged(bool enabled, uint32_t max_pwr);

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -72,7 +72,7 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
   else if (topic_string == mqtt_live_pwr)
   {
       shaper.setLivePwr(payload_str.toInt());
-      DBUGF("shaper: available amps:%dA", shaper.getChgCur());
+      DBUGF("shaper: Live Pwr:%dW", shaper.getLivePwr());
   }
   else if (topic_string == mqtt_vrms)
   {

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -244,7 +244,8 @@ void buildStatus(DynamicJsonDocument &doc) {
 
   doc["shaper"] = shaper.getState()?1:0;
   doc["shaper_live_pwr"] = shaper.getLivePwr();
-  doc["shaper_chg_cur"] = shaper.getChgCur();
+  // doc["shaper_cur"] = shaper.getChgCur();
+  doc["shaper_cur"] = shaper.getMaxCur();
 
   doc["service_level"] = static_cast<uint8_t>(evse.getActualServiceLevel());
 


### PR DESCRIPTION
WARNING! If you were manually changing max_current using HTTP API or MQTT, don't forget to switch to charge_current now