### PR TITLE
Adds is_threephase virtualbool switch.

### DIFF
--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -211,6 +211,7 @@ ConfigOpt *opts[] =
   new ConfigOptVirtualBool(flagsOpt, CONFIG_OCPP_ACCESS_ENERGIZE, CONFIG_OCPP_ACCESS_ENERGIZE, "ocpp_energize_plug", "opn"),
   new ConfigOptVirtualBool(flagsOpt, CONFIG_RFID, CONFIG_RFID, "rfid_enabled", "rf"),
   new ConfigOptVirtualBool(flagsOpt, CONFIG_FACTORY_WRITE_LOCK, CONFIG_FACTORY_WRITE_LOCK, "factory_write_lock", "fwl"),
+  new ConfigOptVirtualBool(flagsOpt, CONFIG_THREEPHASE, CONFIG_THREEPHASE, "is_threephase", "itp"),
   new ConfigOptVirtualMqttProtocol(flagsOpt, "mqtt_protocol", "mprt"),
   new ConfigOptVirtualChargeMode(flagsOpt, "charge_mode", "chmd")
 };

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -96,6 +96,8 @@ extern uint32_t flags;
 #define CONFIG_FACTORY_WRITE_LOCK   (1 << 21)
 #define CONFIG_OCPP_AUTO_AUTH       (1 << 22)
 #define CONFIG_OCPP_OFFLINE_AUTH    (1 << 23)
+#define CONFIG_THREEPHASE           (1 << 24)
+
 
 inline bool config_emoncms_enabled() {
   return CONFIG_SERVICE_EMONCMS == (flags & CONFIG_SERVICE_EMONCMS);
@@ -175,6 +177,10 @@ inline bool config_rfid_enabled() {
 
 inline bool config_factory_write_lock() {
   return CONFIG_FACTORY_WRITE_LOCK == (flags & CONFIG_FACTORY_WRITE_LOCK);
+}
+
+inline bool config_threephase_enabled() {
+  return CONFIG_THREEPHASE == (flags & CONFIG_THREEPHASE);
 }
 
 // Ohm Connect Settings

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -10,6 +10,7 @@
 #include "evse_monitor.h"
 #include "event_log.h"
 #include "json_serialize.h"
+#include "app_config.h"
 
 typedef uint32_t EvseClient;
 
@@ -338,7 +339,12 @@ class EvseManager : public MicroTasks::Task
       return _monitor.isCharging();
     }
     double getAmps() {
-      return _monitor.getAmps();
+      if (!config_threephase_enabled()) {
+        return _monitor.getAmps();
+      }
+      else {
+        return _monitor.getAmps() * 3;
+      }
     }
     double getVoltage() {
       return _monitor.getVoltage();


### PR DESCRIPTION
 Factors _monitor.getAmps() by 3 in _evse.getAmps() if true

This should fix current_shaper & divert mode beeing wrong with threephase, and displays on UI.

fix #472

still needs evse module fw compiled with -D THREEPHASE
