### PR TITLE
Enable Shaper with Divert mode active

### DIFF
--- a/src/current_shaper.h
+++ b/src/current_shaper.h
@@ -17,6 +17,7 @@
 #include "http_update.h"
 #include "input.h"
 #include "event.h"
+#include "divert.h"
 
 class CurrentShaperTask: public MicroTasks::Task
 {
@@ -34,14 +35,12 @@ class CurrentShaperTask: public MicroTasks::Task
   protected:
     void setup();
     unsigned long loop(MicroTasks::WakeReason reason);
-    void shapeCurrent();
-
 
   public:
     CurrentShaperTask();
     ~CurrentShaperTask();
     void begin(EvseManager &evse);
-
+    void shapeCurrent();
     void setMaxPwr(int max_pwr);
     void setLivePwr(int live_pwr);
     void setState(bool state);

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -65,12 +65,21 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
     solar = payload_str.toInt();
     DBUGF("solar:%dW", solar);
     divert.update_state();
+    //recalculate shaper
+    if (shaper.getState()) {
+      shaper.shapeCurrent();
+    }
+      
   }
   else if (topic_string == mqtt_grid_ie)
   {
     grid_ie = payload_str.toInt();
     DBUGF("grid:%dW", grid_ie);
     divert.update_state();
+    //recalculate shaper
+    if (shaper.getState()) {
+      shaper.shapeCurrent();
+    }
   }
   else if (topic_string == mqtt_live_pwr)
   {

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -33,6 +33,7 @@ static bool connecting = false;
 static bool mqttRetained = false;
 uint8_t claimsVersion = 0;
 uint8_t overrideVersion = 0;
+uint8_t scheduleVersion = 0;
 
 String lastWill = "";
 
@@ -521,9 +522,15 @@ mqtt_loop() {
     }
 
     if (overrideVersion != manual.getVersion()) {
-      mqtt_publish_override;
+      mqtt_publish_override();
       DBUGF("Override has changed, publishing to MQTT");
       overrideVersion = manual.getVersion();
+    }
+
+    if (scheduleVersion != scheduler.getVersion()) {
+      mqtt_publish_schedule();
+      DBUGF("Schedule has changed, publishing to MQTT");
+      scheduleVersion = scheduler.getVersion();
     }
   }
   Profile_End(mqtt_loop, 5);

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -245,6 +245,7 @@ void buildStatus(DynamicJsonDocument &doc) {
   doc["charge_rate"] = divert.getChargeRate();
   doc["divert_update"] = (millis() - divert.getLastUpdate()) / 1000;
   doc["divert_active"] = divert.isActive();
+  doc["divertmode"] = (uint8_t)divert.getMode();
 
   doc["shaper"] = shaper.getState()?1:0;
   doc["shaper_live_pwr"] = shaper.getLivePwr();

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -710,12 +710,20 @@ void handleStatusPost(MongooseHttpServerRequest *request, MongooseHttpServerResp
       solar = doc["solar"];
       DBUGF("solar:%dW", solar);
       divert.update_state();
+      // recalculate shaper
+      if (shaper.getState()) {
+        shaper.shapeCurrent();
+      }
       send_event = false; // Divert sends the event so no need to send here
     }
     else if(doc.containsKey("grid_ie")) {
       grid_ie = doc["grid_ie"];
       DBUGF("grid:%dW", grid_ie);
       divert.update_state();
+      // recalculate shaper
+      if (shaper.getState()) {
+        shaper.shapeCurrent();
+      }
       send_event = false; // Divert sends the event so no need to send here
     }
     if(doc.containsKey("battery_level")) {


### PR DESCRIPTION
Now shaper can work while divert is active.
produced energy or grid export is added to shaper max_pwr value
This is mostly necessary when Divert stays at 6amp waiting for smoothed current to get down before shutting down.
If the grid doesn't has enough amp available it can overload. This should prevent it.

and other little commits
