### PR TITLE
fix #452 reevaluate claims if amps > pilot

### DIFF
--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -309,7 +309,6 @@ void EvseMonitor::updateEvseState(uint8_t evse_state, uint8_t pilot_state, uint3
       }
       _session_complete.update(getFlags());
     });
-  verifyPilot();
   }
 }
 

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -317,13 +317,11 @@ void EvseMonitor::verifyPilot() {
     // After some state changes the OpenEVSE module compiled with PP_AUTO_AMPACITY will reset to the maximum pilot level, so reset to what we expect
     _openevse.getCurrentCapacity([this](int ret, long min_current, long max_hardware_current, long pilot, long max_configured_current)
     {
-      DBUGLN("Check pilot is ok");
-      DBUGVAR(pilot);
-      DBUGVAR(getPilot());
-
       if(RAPI_RESPONSE_OK == ret && pilot != getPilot())
       {
         DBUGLN("####  Pilot is wrong set again");
+        DBUGVAR(pilot);
+        DBUGVAR(getPilot());
         _pilot_is_wrong = true;
         setPilot(getPilot());
         _pilot_is_wrong = false;

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -473,7 +473,7 @@ void EvseMonitor::disable()
   });
 }
 
-void EvseMonitor::setPilot(long amps, bool force=false, std::function<void(int ret)> callback)
+void EvseMonitor::setPilot(long amps, bool force, std::function<void(int ret)> callback)
 {
   // limit `amps` to the software limit
   if(amps > _max_configured_current) {

--- a/src/evse_monitor.h
+++ b/src/evse_monitor.h
@@ -155,8 +155,6 @@ class EvseMonitor : public MicroTasks::Task
     char _firmware_version[32];
     char _serial[16];
 
-    bool _pilot_is_wrong;
-
 #ifdef ENABLE_MCP9808
     Adafruit_MCP9808 _mcp9808;
 #endif
@@ -200,7 +198,7 @@ class EvseMonitor : public MicroTasks::Task
 
     void setMaxConfiguredCurrent(long amps);
 
-    void setPilot(long amps, std::function<void(int ret)> callback = NULL);
+    void setPilot(long amps, bool force=false, std::function<void(int ret)> callback = NULL);
     void setVoltage(double volts, std::function<void(int ret)> callback = NULL);
     void setServiceLevel(ServiceLevel level, std::function<void(int ret)> callback = NULL);
     void configureCurrentSensorScale(long scale, long offset, std::function<void(int ret)> callback = NULL);

--- a/src/evse_monitor.h
+++ b/src/evse_monitor.h
@@ -155,6 +155,8 @@ class EvseMonitor : public MicroTasks::Task
     char _firmware_version[32];
     char _serial[16];
 
+    bool _pilot_is_wrong;
+
 #ifdef ENABLE_MCP9808
     Adafruit_MCP9808 _mcp9808;
 #endif
@@ -209,6 +211,7 @@ class EvseMonitor : public MicroTasks::Task
     void enableStuckRelayCheck(bool enabled, std::function<void(int ret)> callback = NULL);
     void enableVentRequired(bool enabled, std::function<void(int ret)> callback = NULL);
     void enableTemperatureCheck(bool enabled, std::function<void(int ret)> callback = NULL);
+    void verifyPilot();
 
     uint8_t getEvseState() {
       return _state.getEvseState();


### PR DESCRIPTION
Until the bug is corrected on evse fw, this solves the issue and prevent the charge_current going to max when Evse goes from Disabled to Active state ignoring claims & pilot values
fix #452 and should also fix #513 fix #388 fix #481

Edit: It seems those bugs are related to PP_AUTO_AMPACITY beeing set. Posted an issue there: https://github.com/lincomatic/open_evse/issues/156?fbclid=IwAR37MVzzv2WZ7iDPPr3lkryBSUIvsDBsbPJkFu5PcZG1JgMT7e2LF6KxFzQ

So this is not really an OpenEvse bug, but more that OpenEvse and Wifi module don't share the non tethered chargers checking cable ampacity state and we have confusions here. 
