### PR TITLE
fix current shaper for threephase + amp display 

### DIFF
--- a/src/current_shaper.cpp
+++ b/src/current_shaper.cpp
@@ -118,7 +118,7 @@ void CurrentShaperTask::shapeCurrent() {
 	_updated = true;
 	// adding self produced energy to total
 	int max_pwr = _max_pwr;
-	if (config_divert_enabled()) {
+	if (config_divert_enabled() == true) {
 		if (mqtt_solar != "") {
 			max_pwr += solar;
 		}		
@@ -126,7 +126,10 @@ void CurrentShaperTask::shapeCurrent() {
 			max_pwr -= grid_ie;
 		}
 	}
-	_max_cur = round(((max_pwr - _live_pwr) / evse.getVoltage()) + (evse.getAmps()));
+	 if(!config_threephase_enabled())
+		_max_cur = round(((max_pwr - _live_pwr) / evse.getVoltage()) + (evse.getAmps()));
+	else
+		_max_cur = round(((max_pwr - _live_pwr) / evse.getVoltage() / 3) + (evse.getAmps()));
 
 
 	_changed = true; 

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -339,12 +339,7 @@ class EvseManager : public MicroTasks::Task
       return _monitor.isCharging();
     }
     double getAmps() {
-      if (!config_threephase_enabled()) {
-        return _monitor.getAmps();
-      }
-      else {
-        return _monitor.getAmps() * 3;
-      }
+      return _monitor.getAmps();
     }
     double getVoltage() {
       return _monitor.getVoltage();


### PR DESCRIPTION
fix mistake in previous pr
revert wrong calc getAmps()*3 for threephase from previous commit ( we don't sum current/phase but power/phase)