### PR TITLE
Fix for infinate loop in getNextEvent

### DIFF
--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -324,13 +324,13 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
         case LcdInfoLine::Time:
           return LcdInfoLine::Date;
         case LcdInfoLine::Date:
-          return _scheduler->getNextEvent().isValid() ?
-                      LcdInfoLine::TimerStart :
-                      LcdInfoLine::EnergySession;
+          if(_scheduler->getNextEvent(EvseState::Active).isValid()) {
+            return LcdInfoLine::TimerStart;
+          }
         case LcdInfoLine::TimerStart:
-          return _scheduler->getNextEvent().isValid() ?
-                      LcdInfoLine::TimerStop :
-                      LcdInfoLine::EnergySession;
+          if(_scheduler->getNextEvent(EvseState::Disabled).isValid()) {
+            return LcdInfoLine::TimerStop;
+          }
         default:
           return LcdInfoLine::EnergySession;
       }
@@ -353,7 +353,7 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
         case LcdInfoLine::EnergyTotal:
           return LcdInfoLine::Temperature;
         case LcdInfoLine::Temperature:
-          if(_scheduler->getNextEvent().isValid()) {
+          if(_scheduler->getNextEvent(EvseState::Disabled).isValid()) {
             return LcdInfoLine::TimerStop;
           }
         case LcdInfoLine::TimerStop:
@@ -388,13 +388,13 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
         case LcdInfoLine::Time:
           return LcdInfoLine::Date;
         case LcdInfoLine::Date:
-          return _scheduler->getNextEvent().isValid() ?
-                      LcdInfoLine::TimerStart :
-                      LcdInfoLine::Time;
+          if(_scheduler->getNextEvent(EvseState::Active).isValid()) {
+            return LcdInfoLine::TimerStart;
+          }
         case LcdInfoLine::TimerStart:
-          return _scheduler->getNextEvent().isValid() ?
-                      LcdInfoLine::TimerStop :
-                      LcdInfoLine::Time;
+          if(_scheduler->getNextEvent(EvseState::Disabled).isValid()) {
+            return LcdInfoLine::TimerStop;
+          }
         default:
           return LcdInfoLine::Time;
       }

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -16,6 +16,8 @@
 
 uint32_t Scheduler::Event::_next_id = 1;
 
+Scheduler::EventInstance nullEventInstance;
+
 const char * days_of_the_week_strings[] = {
   "sunday",
   "monday",
@@ -422,14 +424,23 @@ Scheduler::EventInstance &Scheduler::getCurrentEvent()
 
 Scheduler::EventInstance &Scheduler::getNextEvent(EvseState type)
 {
+  DBUGVAR(type);
   EventInstance *event = &_activeEvent; // Assume active event is correct
   if(event->isValid())
   {
     event = &event->getNext();
     if(EvseState::None != type)
     {
-      while(event->getState() != type) {
+      EventInstance *startEvent = event;
+
+      while(event->getState() != type)
+      {
         event = &event->getNext();
+        DBUGVAR((uint32_t)event, HEX);
+        DBUGVAR((uint32_t)startEvent, HEX);
+        if(startEvent == event) {
+          return nullEventInstance;
+        }
       }
     }
   }


### PR DESCRIPTION
getNextEvent could get stuck in an infinate loop if searching for a type that is not in the list. This can happen when there is only enteries ofa single type, eg disabled and you search for active, as the LCD module does causing a watchdog timeout.

Fixes #414