### PR TITLE
ping pong over websocket

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1067,7 +1067,8 @@ void onWsFrame(MongooseHttpWebSocketConnection *connection, int flags, uint8_t *
     if (doc.containsKey("ping") && doc["ping"].is<int8_t>())
       {
         // answer pong
-        server.sendAll("/ws", "{\"pong\": 1}");
+        connection->send("{\"pong\": 1}");
+        
       }
   }
 }

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1060,6 +1060,16 @@ void handleNotFound(MongooseHttpServerRequest *request)
 void onWsFrame(MongooseHttpWebSocketConnection *connection, int flags, uint8_t *data, size_t len)
 {
   DBUGF("Got message %.*s", len, (const char *)data);
+  const size_t capacity = JSON_OBJECT_SIZE(1) + 16;
+  DynamicJsonDocument doc(capacity);
+  DeserializationError error = deserializeJson(doc, data, len);
+  if (!error) {
+    if (doc.containsKey("ping") && doc["ping"].is<int8_t>())
+      {
+        // answer pong
+        server.sendAll("/ws", "{\"pong\": 1}");
+      }
+  }
 }
 
 void onWsConnect(MongooseHttpWebSocketConnection *connection)


### PR DESCRIPTION
let wifi module answer to ping over websocket
Handled on UIv2 (pingpong branch ) for proper disconnection/reconnection
( client send a ping if it hasn't received data for 5sec ) , tries 3 times each sec if it doesn't get an answer, then tries to reconnect to server ) . Behavior could be mirrored on UI1 too ( no need to send a ping each sec anymore  ) 