### PR TITLE
add missing energyMeter data to emoncmss_publish()

### DIFF
--- a/src/energy_meter.cpp
+++ b/src/energy_meter.cpp
@@ -8,7 +8,6 @@
 #include "app_config.h"
 #include "event.h"
 
-
 EnergyMeterData::EnergyMeterData()
 {
     total = 0;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -147,6 +147,12 @@ void create_rapi_json(JsonDocument &doc)
   doc["srssi"] = WiFi.RSSI();
 
   timeManager.serialise(doc);
+  // get EnergyMeter data
+  evse.createEnergyMeterJsonDoc(doc);
+  // Deprecated properties, will be removed soon
+  doc["elapsed"] = evse.getSessionElapsed();
+  doc["wattsec"] = evse.getSessionEnergy() * SESSION_ENERGY_SCALE_FACTOR;
+  doc["watthour"] = evse.getTotalEnergy() * TOTAL_ENERGY_SCALE_FACTOR;
 }
 
 void

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -243,7 +243,8 @@ loop() {
     if(emoncms_updated)
     {
       // Send the current state to check the config
-      DynamicJsonDocument data(4096);
+      const size_t capacity = JSON_OBJECT_SIZE(33) + 1024;
+      DynamicJsonDocument data(capacity);
       create_rapi_json(data);
       emoncms_publish(data);
       emoncms_updated = false;

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -232,7 +232,6 @@ void buildStatus(DynamicJsonDocument &doc) {
   doc["evse_connected"] = (int)evse.isConnected();
 
   create_rapi_json(doc);
-  evse.createEnergyMeterJsonDoc(doc);
 
   doc["gfcicount"] = evse.getFaultCountGFCI();
   doc["nogndcount"] = evse.getFaultCountNoGround();
@@ -280,10 +279,6 @@ void buildStatus(DynamicJsonDocument &doc) {
       doc["time_to_full_charge"] = evse.getVehicleEta();
     }
   }
-  // Deprecated properties, will be removed soon
-  doc["elapsed"] = evse.getSessionElapsed();
-  doc["wattsec"] = evse.getSessionEnergy() * SESSION_ENERGY_SCALE_FACTOR;
-  doc["watthour"] = evse.getTotalEnergy() * TOTAL_ENERGY_SCALE_FACTOR;
 
   DBUGF("/status ArduinoJson size: %dbytes", doc.size());
 }
@@ -434,7 +429,7 @@ void handleStatusPost(MongooseHttpServerRequest *request, MongooseHttpServerResp
 {
   String body = request->body().toString();
   // Deserialize the JSON document
-  const size_t capacity = JSON_OBJECT_SIZE(128) + 1024;
+  const size_t capacity = JSON_OBJECT_SIZE(32) + 1024;
   DynamicJsonDocument doc(capacity);
   DeserializationError error = deserializeJson(doc, body);
   if(!error)
@@ -515,7 +510,7 @@ handleStatus(MongooseHttpServerRequest *request)
 
   if(HTTP_GET == request->method()) {
 
-    const size_t capacity = JSON_OBJECT_SIZE(80) + 1280;
+    const size_t capacity = JSON_OBJECT_SIZE(128) + 2048;
     DynamicJsonDocument doc(capacity);
     buildStatus(doc);
     response->setCode(200);


### PR DESCRIPTION
forgot this one

Also put the deprecated properties in create_rapi_json as they are missing for emoncms publish

( time to ask emoncms to use the new properties before deprecation )

edit: is there a good reason why data are sent separately to emoncms instead of using event_send like websocket & mqtt?
Also it seems we should send the full /status topic to emoncms instead of create_rapi_json as more data are now coming from ESP32 and not RAPI. 