### PR TITLE
some EnergyMeter fixes

### DIFF
--- a/src/energy_meter.cpp
+++ b/src/energy_meter.cpp
@@ -79,10 +79,10 @@ void EnergyMeterData::deserialize(StaticJsonDocument<capacity> &doc)
         // daily
         daily = doc["dy"];
     }
-    if (doc.containsKey("we") && doc["we"].is<double>())
+    if (doc.containsKey("wk") && doc["wk"].is<double>())
     {
         // weekly
-        weekly = doc["we"];
+        weekly = doc["wk"];
     }
     if (doc.containsKey("mo") && doc["mo"].is<double>())
     {

--- a/src/energy_meter.cpp
+++ b/src/energy_meter.cpp
@@ -196,6 +196,7 @@ void EnergyMeter::end()
 bool EnergyMeter::reset(bool full = false, bool import = false)
 {
     if (createEnergyMeterStorage(full, import)) {
+        publish();
         return true;
     }
     else

--- a/src/energy_meter.cpp
+++ b/src/energy_meter.cpp
@@ -289,7 +289,7 @@ bool EnergyMeter::update()
     double kwh = wh / 1000UL;
     _data.total += kwh;
     DBUGVAR(_data.session);
-    _data.daily += kwh;
+    _data.daily += kwh; 
     _data.weekly += kwh;
     _data.monthly += kwh;
     _data.yearly += kwh;
@@ -374,10 +374,6 @@ void EnergyMeter::rotate()
     {
         save();
         publish();
-    }
-    if (!_monitor->isVehicleConnected() && _data.elapsed)
-    {
-        _data.elapsed = 0;
     }
 };
 

--- a/src/energy_meter.cpp
+++ b/src/energy_meter.cpp
@@ -82,7 +82,7 @@ void EnergyMeterData::deserialize(StaticJsonDocument<capacity> &doc)
     if (doc.containsKey("we") && doc["we"].is<double>())
     {
         // weekly
-        daily = doc["we"];
+        weekly = doc["we"];
     }
     if (doc.containsKey("mo") && doc["mo"].is<double>())
     {
@@ -286,13 +286,13 @@ bool EnergyMeter::update()
     // convert to w/h
     double wh = mws / 3600000UL;
     _data.session += wh;
-    _data.total += wh / 1000;
+    double kwh = wh / 1000UL;
+    _data.total += kwh;
     DBUGVAR(_data.session);
-
-    _data.daily += wh / 1000;
-    _data.weekly += wh / 1000;
-    _data.monthly += wh / 1000;
-    _data.yearly += wh / 1000;
+    _data.daily += kwh;
+    _data.weekly += kwh;
+    _data.monthly += kwh;
+    _data.yearly += kwh;
 
     _last_upd = curms;
     DBUGF("session_wh = %.2f, total_kwh = %.2f", _data.session, _data.total);


### PR DESCRIPTION
fix monthly counter wrong
session data initialised at reboot
fix time now using localtime for rotate()
publish energyMeter after counters reset