### PR TITLE
Fixes to the auto version number script

### DIFF
--- a/.github/workflows/release_validation.yaml
+++ b/.github/workflows/release_validation.yaml
@@ -51,10 +51,15 @@ jobs:
       ### Check the version number in the code matches the tag number
       - uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
       - name: Retrieve the version number(s)
         run: |
           TAG_VERSION=$GITHUB_REF_NAME
-          CODE_VERSION=$(git describe --tags)
+          CODE_VERSION=$(python3 scripts/auto_fw_version.py | grep -E 'BUILD_TAG=([^ ]+)' -o | cut -d= -f2)
           echo TAG_VERSION=$TAG_VERSION >> $GITHUB_ENV
           echo CODE_VERSION=$CODE_VERSION >> $GITHUB_ENV
 

--- a/scripts/auto_fw_version.py
+++ b/scripts/auto_fw_version.py
@@ -1,8 +1,6 @@
 import subprocess
 import os
 
-Import("env")
-
 def get_build_flag():
     ret = subprocess.run(["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE, text=True) #Uses any tags
     full_hash = ret.stdout.strip()
@@ -27,15 +25,15 @@ def get_build_flag():
 
     build_flags = "-D BUILD_TAG=" + build_version + " " + "-D BUILD_HASH=" + short_hash + ""
 
-    print ("Firmware Revision: " + build_flags)
     return build_flags
 
-    ret = subprocess.run(["git", "describe", "--tags"], stdout=subprocess.PIPE, text=True) #Uses any tags
-    build_version = ret.stdout.strip()
-    build_flags = "-D BUILD_TAG=" + build_version
-    print ("Firmware Revision: " + build_flags)
-    return build_flags
+build_flags = get_build_flag()
 
-env.Append(
-    BUILD_FLAGS=[get_build_flag()]
-)
+if "SCons.Script" == __name__:
+    print ("Firmware Revision: " + build_flags)
+    Import("env")
+    env.Append(
+        BUILD_FLAGS=[get_build_flag()]
+    )
+elif "__main__" == __name__:
+    print(build_flags)

--- a/scripts/auto_fw_version.py
+++ b/scripts/auto_fw_version.py
@@ -3,15 +3,38 @@ import os
 
 Import("env")
 
-
-
 def get_build_flag():
-    #ret = subprocess.run(["git", "describe"], stdout=subprocess.PIPE, text=True) #Uses only annotated tags
+    ret = subprocess.run(["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE, text=True) #Uses any tags
+    full_hash = ret.stdout.strip()
+    short_hash = full_hash[:8]
+
+    build_version = "local_" + short_hash
+
+    # get the GITHUB_REF_NAME
+    ref_name = os.environ.get('GITHUB_REF_NAME')
+    if ref_name:
+        if ref_name.startswith("v"):
+            build_version = ref_name
+        else:
+            build_version = ref_name + "_" + short_hash
+
+    # Check if the source has been modified since the last commit
+    ret = subprocess.run(["git", "diff-index", "--quiet", "HEAD", "--"], stdout=subprocess.PIPE, text=True)
+    if ret.returncode != 0:
+        build_version += "_modified"
+        short_hash += "_modified"
+        full_hash += "_modified"
+
+    build_flags = "-D BUILD_TAG=" + build_version + " " + "-D BUILD_HASH=" + short_hash + ""
+
+    print ("Firmware Revision: " + build_flags)
+    return build_flags
+
     ret = subprocess.run(["git", "describe", "--tags"], stdout=subprocess.PIPE, text=True) #Uses any tags
     build_version = ret.stdout.strip()
-    build_flag = "-D BUILD_TAG=" + build_version
-    print ("Firmware Revision: " + build_flag)
-    return (build_flag)
+    build_flags = "-D BUILD_TAG=" + build_version
+    print ("Firmware Revision: " + build_flags)
+    return build_flags
 
 env.Append(
     BUILD_FLAGS=[get_build_flag()]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,6 +106,7 @@ void setup()
   DEBUG.println();
   DEBUG.printf("OpenEVSE WiFI %s\n", ESPAL.getShortId().c_str());
   DEBUG.printf("Firmware: %s\n", currentfirmware.c_str());
+  DEBUG.printf("Git Hash: " ESCAPEQUOTE(BUILD_HASH) "\n");
   DEBUG.printf("Build date: " __DATE__ " " __TIME__ "\n");
   DEBUG.printf("IDF version: %s\n", ESP.getSdkVersion());
   DEBUG.printf("Free: %d\n", ESPAL.getFreeHeap());


### PR DESCRIPTION
Updated the auto version number script to use the correct GitHub environment variables to get the version number when running on GitHub Actions.

Added the `_modified` suffix to the version number when the working directory is not clean. This is to ensure that the version number is always different when the working directory is not clean.

Added the `GIT_HASH` define with the short hash of the current commit. This is to make it easier to identify the exact commit that was used to build the binary.

Fixes #584