### PR TITLE
Add support for Wemos D1 Mini ESP32

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,7 @@ jobs:
       matrix:
         env:
           - openevse_nodemcu-32s
+          - openevse_wemos_d1_mini32
           - openevse_esp-wrover-kit
           - openevse_esp-wrover-kit_latest
           - openevse_huzzah32_dev

--- a/platformio.ini
+++ b/platformio.ini
@@ -139,6 +139,16 @@ build_flags =
   -D WIFI_LED_ON_STATE=LOW
   -D RAPI_PORT=Serial2
 
+[env:wemos_d1_mini32]
+board = wemos_d1_mini32
+build_flags =
+  ${common.build_flags}
+  ${common.src_build_flags}
+  ${common.debug_flags}
+  -D WIFI_LED=2
+  -D WIFI_LED_ON_STATE=LOW
+  -D RAPI_PORT=Serial2
+
 [env:openevse_esp-wrover-kit]
 board = esp-wrover-kit
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -139,7 +139,7 @@ build_flags =
   -D WIFI_LED_ON_STATE=LOW
   -D RAPI_PORT=Serial2
 
-[env:wemos_d1_mini32]
+[env:openevse_wemos_d1_mini32]
 board = wemos_d1_mini32
 build_flags =
   ${common.build_flags}


### PR DESCRIPTION
I can confirm that we can flash version 4.2.2 on the Wemos D1 Mini ESP32 with this profile and we can connect to the OpenEVSE card successfully. 
- TX pin of the ESP has to be connected to the RX pin of the OpenEVSE card
- RX pin of the ESP has to be connected to the TX pin of the OpenEVSE card