### PR TITLE
Expose restart and max_current through mqtt

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -48,6 +48,8 @@ Main settings:
 
 `<base-topic>/divertmode/set [1 | 2]`       : enable (1)/ disable (2) divert mode  
 `<base-topic>/shaper/set [0 | 1]`       : temporary enable (1)/ disable (0) current shaper ( doesn't survive reboot )  
+`<base-topic>/restart`                  : restarts the gateway
+
 
 
 MQTT setup is pre-populated with OpenEnergyMonitor [emonPi default MQTT server credentials](https://guide.openenergymonitor.org/technical/credentials/#mqtt).

--- a/src/divert.cpp
+++ b/src/divert.cpp
@@ -245,10 +245,10 @@ void DivertTask::update_state()
       if(_state != current_evse_state)
       {
         _state = current_evse_state;
-        event["divert_active"] = isActive();
       }
     }
 
+    event["divert_active"] = isActive();
     event["charge_rate"] = _charge_rate;
     event["trigger_current"] = trigger_current;
     event["voltage"] = voltage;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -73,6 +73,7 @@ class InputTask : public MicroTasks::Task
         event["vehicle"] = evse.isVehicleConnected() ? 1 : 0;
         event["colour"] = evse.getStateColour();
         event["pilot"] = evse.getChargeCurrent();
+        event["max_current"] = evse.getMaxCurrent();
         event["manual_override"] = manual.isActive() ? 1 : 0; //TODO: remove this
         event["status"] = evse.getState().toString();
         event["elapsed"] = evse.getSessionElapsed();
@@ -104,6 +105,7 @@ void create_rapi_json(JsonDocument &doc)
   doc["voltage"] = evse.getVoltage() * VOLTS_SCALE_FACTOR;
   doc["power"] = evse.getPower() * POWER_SCALE_FACTOR;
   doc["pilot"] = evse.getChargeCurrent();
+  doc["max_current"] = evse.getMaxCurrent();
   if(evse.isTemperatureValid(EVSE_MONITOR_TEMP_MONITOR)) {
     doc["temp"] = evse.getTemperature(EVSE_MONITOR_TEMP_MONITOR) * TEMP_SCALE_FACTOR;
   } else {

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -183,6 +183,11 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
     mqtt_clear_schedule(payload_str.toInt());
   }
 
+  // Restart
+  else if (topic_string == mqtt_topic + "/restart") {
+    restart_system();
+  }
+
   else
   {
     // If MQTT message is RAPI command
@@ -360,6 +365,12 @@ mqtt_connect()
     mqtt_sub_topic = mqtt_topic + "/schedule/clear";
     mqttclient.subscribe(mqtt_sub_topic);
     yield();
+
+    // ask for a system restart
+    mqtt_sub_topic = mqtt_topic + "/restart";
+    mqttclient.subscribe(mqtt_sub_topic);
+    yield();
+
     connecting = false;
   });
 


### PR DESCRIPTION
Using the RAPI MQTT topic to set the max_current_soft ($SC) does not correctly refresh the UI. It's best to expose it. Also, restart of the gateway was missing.