### PR TITLE
switch from 404 to 200 response from REST API when there's no error

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -543,7 +543,7 @@ handleScheduleGet(MongooseHttpServerRequest *request, MongooseHttpServerResponse
     response->setCode(200);
     serializeJson(doc, *response);
   } else {
-    response->setCode(404);
+    response->setCode(200);
     response->print("{\"msg\":\"Not found\"}");
   }
 }
@@ -575,7 +575,7 @@ handleScheduleDelete(MongooseHttpServerRequest *request, MongooseHttpServerRespo
       response->setCode(200);
       response->print("{\"msg\":\"done\"}");
     } else {
-      response->setCode(404);
+      response->setCode(200);
       response->print("{\"msg\":\"Not found\"}");
     }
   } else {
@@ -649,7 +649,7 @@ void handleLimitGet(MongooseHttpServerRequest *request, MongooseHttpServerRespon
   {
     limit.get().serialize(response);
   } else {
-    response->setCode(404);
+    response->setCode(200);
     response->print("{\"msg\":\"no limit\"}");
   }
 }
@@ -681,7 +681,7 @@ void handleLimitDelete(MongooseHttpServerRequest *request, MongooseHttpServerRes
       response->print("{\"msg\":\"failed\"}");
     }
   } else {
-    response->setCode(404);
+    response->setCode(200);
     response->print("{\"msg\":\"no limit\"}");
   }
 }
@@ -775,7 +775,7 @@ void handleEmeter(MongooseHttpServerRequest *request)
       manual.getProperties(props);
       props.serialize(response);
     } else {
-    response->setCode(404);
+    response->setCode(200);
     response->print("{\"msg\":\"No manual override\"}");
   }
 }

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -543,7 +543,7 @@ handleScheduleGet(MongooseHttpServerRequest *request, MongooseHttpServerResponse
     response->setCode(200);
     serializeJson(doc, *response);
   } else {
-    response->setCode(200);
+    response->setCode(404);
     response->print("{\"msg\":\"Not found\"}");
   }
 }
@@ -575,7 +575,7 @@ handleScheduleDelete(MongooseHttpServerRequest *request, MongooseHttpServerRespo
       response->setCode(200);
       response->print("{\"msg\":\"done\"}");
     } else {
-      response->setCode(200);
+      response->setCode(404);
       response->print("{\"msg\":\"Not found\"}");
     }
   } else {
@@ -650,7 +650,7 @@ void handleLimitGet(MongooseHttpServerRequest *request, MongooseHttpServerRespon
     limit.get().serialize(response);
   } else {
     response->setCode(200);
-    response->print("{\"msg\":\"no limit\"}");
+    response->print("{}");
   }
 }
 
@@ -664,7 +664,7 @@ void handleLimitPost(MongooseHttpServerRequest *request, MongooseHttpServerRespo
       // todo: mqtt_publish_limit();  // update limit props to mqtt
     } else {
       // unused for now
-      response->setCode(500);
+      response->setCode(400);
       response->print("{\"msg\":\"failed to parse JSON\"}");
     }
 }
@@ -675,7 +675,6 @@ void handleLimitDelete(MongooseHttpServerRequest *request, MongooseHttpServerRes
     if (limit.clear()) {
       response->setCode(200);
       response->print("{\"msg\":\"done\"}");
-      // todo: mqtt_publish_limit();  // update limit props to mqtt
     } else {
       response->setCode(500);
       response->print("{\"msg\":\"failed\"}");
@@ -776,7 +775,7 @@ void handleEmeter(MongooseHttpServerRequest *request)
       props.serialize(response);
     } else {
     response->setCode(200);
-    response->print("{\"msg\":\"No manual override\"}");
+    response->print("{}");
   }
 }
 
@@ -796,7 +795,7 @@ void handleOverridePost(MongooseHttpServerRequest *request, MongooseHttpServerRe
       response->print("{\"msg\":\"Failed to claim manual overide\"}");
     }
   } else {
-    response->setCode(500);
+    response->setCode(400);
     response->print("{\"msg\":\"Failed to parse JSON\"}");
   }
 }
@@ -917,12 +916,12 @@ handleRestart(MongooseHttpServerRequest *request) {
         }
       }
       else {
-        response->setCode(405);
+        response->setCode(400);
         response->print("{\"msg\":\"wrong payload\"}");
         request->send(response);
       }
     } else {
-      response->setCode(405);
+      response->setCode(400);
       response->print("{\"msg\":\"Couldn't parse json\"}");
       request->send(response);
     }


### PR DESCRIPTION
Fix browser console spawning HTTP 404 error when API answer was correct. Was preventing to catch real 404 errors.

@jeremypoulter , do you think we should also change the {msg: "no override"} and co by empty objects {} ?